### PR TITLE
Add huntr.dev to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Reporting a Vulnerability
+
+If you discover a security vulnerability in benharvie.github.io please disclose it via [our huntr page](https://huntr.dev/repos/benharvie/benharvie.github.io/). Information about bounties, CVEs, response times and past reports are all there..
+
+Thank you for improving the security of benharvie.github.io.


### PR DESCRIPTION
As requested through the platform by @jamieslome, this will point your security policy to [huntr.dev](https://huntr.dev/repos/benharvie/benharvie.github.io})